### PR TITLE
adding a customer stub with an outline hexagonal structure

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/jonathanwamsley/banking/domain"
+	"github.com/jonathanwamsley/banking/service"
+)
+
+// Start helps decouples from running the whole entire application
+// it connects the handlers, starts the server, and any other configuration setup
+func Start() {
+	router := mux.NewRouter()
+	
+	ch := CustomerHandler{service.NewCustomerService(domain.NewCustomerRepositoryStub())}
+	router.HandleFunc("/customers", ch.GetAllCustomers).Methods(http.MethodGet)
+	log.Fatal(http.ListenAndServe(":8080", router))
+}

--- a/app/customer_handlers.go
+++ b/app/customer_handlers.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jonathanwamsley/banking/service"
+)
+
+// CustomerHandler connects routing parateters and the CustomerService being called
+type CustomerHandler struct {
+	service service.CustomerService
+}
+
+// GetAllCustomers returns all customers
+// 
+func (ch *CustomerHandler) GetAllCustomers(w http.ResponseWriter, r *http.Request) {
+	customers, err := ch.service.GetAllCustomers()
+
+	if err != nil {
+		writeResponse(w, http.StatusNotFound, "something went wrong")
+	} else {
+		writeResponse(w, http.StatusOK, customers)
+	}
+}
+
+func writeResponse(w http.ResponseWriter, code int, data interface{}) {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		panic(err)
+	}
+}

--- a/domain/customer.go
+++ b/domain/customer.go
@@ -1,0 +1,18 @@
+package domain
+
+// Customer hold locality information are are owners of accounts
+type Customer struct {
+	ID          string
+	Name        string
+	City        string
+	Zipcode     string
+	DateofBirth string
+	Status      string
+}
+
+// CustomerRepository implements:
+//
+// FindAll: returns all the customers or an error
+type CustomerRepository interface {
+	FindAll() ([]Customer, error)
+}

--- a/domain/customer_repository_stub.go
+++ b/domain/customer_repository_stub.go
@@ -1,0 +1,20 @@
+package domain
+
+// CustomerRepositoryStub is used to test basic api functionality before implementing a db
+type CustomerRepositoryStub struct {
+	customers []Customer
+}
+
+// FindAll returns all customers
+func (s CustomerRepositoryStub) FindAll() ([]Customer, error) {
+	return s.customers, nil
+}
+
+// NewCustomerRepositoryStub creates the mock data
+func NewCustomerRepositoryStub() CustomerRepositoryStub {
+	customers := []Customer{
+		{"1001", "Ashish", "New Delhi", "110011", "2000-01-01", "1"},
+		{"1002", "Rob", "New Delhi", "110011", "2000-01-01", "1"},
+	}
+	return CustomerRepositoryStub{customers}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jonathanwamsley/banking
+
+go 1.15
+
+require github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/jonathanwamsley/banking/app"
+
+func main() {
+	app.Start()
+}

--- a/service/customer_service.go
+++ b/service/customer_service.go
@@ -1,0 +1,29 @@
+package service
+
+import "github.com/jonathanwamsley/banking/domain"
+
+// CustomerService is an interface that implements
+//
+// GetAllCustomer: returns all the customers or an error
+type CustomerService interface {
+	GetAllCustomers() ([]domain.Customer, error)
+}
+
+// DefaultCustomerService has methods that call upon dto and domain
+type DefaultCustomerService struct {
+	repo domain.CustomerRepository
+}
+
+// NewCustomerService is the entry point to the service to create a DefaultCustomerService struct
+func NewCustomerService(repository domain.CustomerRepository) DefaultCustomerService {
+	return DefaultCustomerService{repository}
+}
+
+// GetAllCustomers returns all the customers or an error
+func (s DefaultCustomerService) GetAllCustomers() ([]domain.Customer, error) {
+	customers, err := s.repo.FindAll()
+	if err != nil {
+		return nil, err
+	}
+	return customers, nil
+}


### PR DESCRIPTION
The hexagonal architecture layout has been created with a customer stub. The server can be run and then in another terminal you can curl localhost:8080/customers to get the customer stub data.