### PR TITLE
adding delete account route

### DIFF
--- a/app/account_handlers.go
+++ b/app/account_handlers.go
@@ -23,11 +23,13 @@ func (ah *AccountHandler) CreateAccount(w http.ResponseWriter, r *http.Request) 
 	accountRequest.CustomerID = id
 	if err := json.NewDecoder(r.Body).Decode(&accountRequest); err != nil {
 		writeResponse(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	result, err := ah.service.CreateAccount(accountRequest)
 	if err != nil {
 		writeResponse(w, err.Code, err.Message)
+		return
 	}
 	writeResponse(w, http.StatusCreated, result)
 }
@@ -39,6 +41,7 @@ func (ah *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
 	result, err := ah.service.GetAccount(id)
 	if err != nil {
 		writeResponse(w, err.Code, err.Message)
+		return
 	}
 	writeResponse(w, http.StatusOK, result)
 }
@@ -57,6 +60,7 @@ func (ah *AccountHandler) DeleteAccount(w http.ResponseWriter, r *http.Request) 
 	err := ah.service.DeleteAccount(id, accountType)
 	if err != nil {
 		writeResponse(w, err.Code, err.Message)
+		return
 	}
 	writeResponse(w, http.StatusOK, map[string]string{"status": "deleted"})
 }

--- a/app/account_handlers.go
+++ b/app/account_handlers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/jonathanwamsley/banking/dto"
+	"github.com/jonathanwamsley/banking/errs"
 	"github.com/jonathanwamsley/banking/service"
 )
 
@@ -40,4 +41,26 @@ func (ah *AccountHandler) GetAccount(w http.ResponseWriter, r *http.Request) {
 		writeResponse(w, err.Code, err.Message)
 	}
 	writeResponse(w, http.StatusOK, result)
+}
+
+// DeleteAccount uses a account type query and a customer_id to delete an account
+func (ah *AccountHandler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["customer_id"]
+	accountType := r.URL.Query().Get("account_type")
+
+	if badAccountType(accountType) {
+		err := errs.NewNotFoundError("invalid query parameter for account_type")
+		writeResponse(w, err.Code, err.AsMessage())
+		return
+	}
+
+	err := ah.service.DeleteAccount(id, accountType)
+	if err != nil {
+		writeResponse(w, err.Code, err.Message)
+	}
+	writeResponse(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func badAccountType(accountType string) bool {
+	return accountType != "checking" && accountType != "saving"
 }

--- a/app/app.go
+++ b/app/app.go
@@ -59,6 +59,7 @@ func Start() {
 
 	router.HandleFunc("/customers/{customer_id:[0-9]+}/account", ah.CreateAccount).Methods(http.MethodPost)
 	router.HandleFunc("/customers/{customer_id:[0-9]+}/account", ah.GetAccount).Methods(http.MethodGet)
+	router.HandleFunc("/customers/{customer_id:[0-9]+}/account", ah.DeleteAccount).Methods(http.MethodDelete)
 
 	logger.Info(fmt.Sprintf("Starting server on %s ...", serverInfo))
 	log.Fatal(http.ListenAndServe(serverInfo, router))

--- a/app/customer_handlers.go
+++ b/app/customer_handlers.go
@@ -20,6 +20,7 @@ func (ch *CustomerHandler) GetAllCustomers(w http.ResponseWriter, r *http.Reques
 
 	if err != nil {
 		writeResponse(w, err.Code, err.AsMessage())
+		return
 	}
 	writeResponse(w, http.StatusOK, customers)
 }
@@ -29,10 +30,12 @@ func (ch *CustomerHandler) CreateCustomer(w http.ResponseWriter, r *http.Request
 	var customerRequest dto.CustomerRequest
 	if err := json.NewDecoder(r.Body).Decode(&customerRequest); err != nil {
 		writeResponse(w, http.StatusBadRequest, "invalid json")
+		return
 	}
 	customer, err := ch.service.CreateCustomer(customerRequest)
 	if err != nil {
 		writeResponse(w, err.Code, err.AsMessage())
+		return
 	}
 	writeResponse(w, http.StatusOK, customer)
 }

--- a/domain/account.go
+++ b/domain/account.go
@@ -21,9 +21,12 @@ type Account struct {
 // AccountRepository implements:
 //
 // Save: creates a new account for a customer, and returns customer account id
+// ById: searches for accounts by a user_id
+// Delete: deletes an account using a customer id and account type
 type AccountRepository interface {
 	Save(Account) (*Account, *errs.AppError)
 	ByID(string) ([]Account, *errs.AppError)
+	Delete(id string, accountType string) *errs.AppError
 }
 
 // ToCreateAccountResponseDTO converts account from database to account response for user

--- a/domain/account_repository_db.go
+++ b/domain/account_repository_db.go
@@ -60,10 +60,15 @@ func (d AccountRepositoryDB) ByID(id string) ([]Account, *errs.AppError) {
 
 // Delete returns nil for a customer of a given account type
 func (d AccountRepositoryDB) Delete(id string, accountType string) *errs.AppError {
-	_, err := d.client.Exec(deleteAccount, id, accountType)
+	result, err := d.client.Exec(deleteAccount, id, accountType)
 	if err != nil {
 		logger.Error("Error while trying to delete account " + err.Error())
 		return errs.NewUnexpectedError("Unexpected error from database")
+	}
+
+	rowsChanged, _ := result.RowsAffected()
+	if rowsChanged == 0 {
+		return errs.NewNotFoundError("Account not found")
 	}
 	return nil
 }

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/jonathanwamsley/banking/domain"
 	"github.com/jonathanwamsley/banking/dto"
 	"github.com/jonathanwamsley/banking/errs"
@@ -29,6 +31,14 @@ func NewAccountService(repository domain.AccountRepository) DefaultAccountServic
 
 // CreateAccount manages the account dto and database interaction
 func (s DefaultAccountService) CreateAccount(req dto.CreateAccountRequest) (*dto.CreateAccountResponse, *errs.AppError) {
+
+	accounts, _ := s.repo.ByID(req.CustomerID)
+	for _, a := range accounts {
+		if a.AccountType == req.AccountType {
+			return nil, errs.NewValidationError(fmt.Sprintf("Error, only one %s type is allow", req.AccountType))
+		}
+	}
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -57,7 +67,17 @@ func (s DefaultAccountService) GetAccount(id string) ([]dto.GetAccountResponse, 
 
 // DeleteAccount deletes an account using a customer_id and account_type
 func (s DefaultAccountService) DeleteAccount(id string, accountType string) *errs.AppError {
-	err := s.repo.Delete(id, accountType)
+	accounts, err := s.repo.ByID(id)
+	if err != nil {
+		return err
+	}
+	for _, a := range accounts {
+		if a.AccountType == accountType && a.Amount != 0 {
+			return errs.NewValidationError("Account must have a balance of 0 to close")
+		}
+	}
+
+	err = s.repo.Delete(id, accountType)
 	if err != nil {
 		return err
 	}

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -10,9 +10,11 @@ import (
 //
 // CreateAccount: creates a new account for a given customer and returns account id back on success
 // GetAccount: gets the user checking and savings account
+// DeleteAccount: deletes a user account
 type AccountService interface {
 	CreateAccount(dto.CreateAccountRequest) (*dto.CreateAccountResponse, *errs.AppError)
 	GetAccount(id string) ([]dto.GetAccountResponse, *errs.AppError)
+	DeleteAccount(id string, accountType string) *errs.AppError
 }
 
 // DefaultAccountService has methods that call dto and the domain
@@ -51,4 +53,13 @@ func (s DefaultAccountService) GetAccount(id string) ([]dto.GetAccountResponse, 
 		response = append(response, a.ToGetAccountResponseDTO())
 	}
 	return response, nil
+}
+
+// DeleteAccount deletes an account using a customer_id and account_type
+func (s DefaultAccountService) DeleteAccount(id string, accountType string) *errs.AppError {
+	err := s.repo.Delete(id, accountType)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
added a delete account that requires the user to specify a query url. This query must be either checking or saving looking like
/customers/2001/?status=checking for example. Then, on success the user will be informed that is was deleted.